### PR TITLE
[Refactor/#85] 예매 페이지 깜빡거림 개선

### DIFF
--- a/src/pages/movie-reservation/components/Chip.tsx
+++ b/src/pages/movie-reservation/components/Chip.tsx
@@ -12,7 +12,7 @@ const variants = {
     style: 'border-[0.05rem] rounded-[0.6rem] border-gray-600 bg-gray-800',
     selectedStyle: 'border-gradient-1',
     text: 'font-button2 text-gray-0 opacity-40',
-    selectedText: 'font-button3 text-gray-0',
+    selectedText: 'text-[1.4rem] font-bold leading-[150%] tracking-[-0.05em] text-gray-0',
   },
   date: {
     layout: 'flex flex-col justify-end gap-[0.2rem] shrink-0 w-[4.8rem] h-[5.2rem] px-[0.8rem] py-[0.5rem]',

--- a/src/pages/movie-reservation/hooks/use-cinemas.ts
+++ b/src/pages/movie-reservation/hooks/use-cinemas.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { apiRequest } from '@api/api-request';
 import type { ApiResponseCinemaListResponse } from '@/../apis/data-contracts';
 import { MOVIE_KEY } from '@/shared/query-key/movie';
@@ -17,5 +17,6 @@ export function useCinemas(movieIds: number[]) {
     queryKey: MOVIE_KEY.CINEMAS(movieIds),
     queryFn: () => getCinemas(movieIds),
     enabled: movieIds.length > 0,
+    placeholderData: keepPreviousData,
   });
 }


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #85 

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

<!-- 작업한 내용을 작성해주세요 -->
- [x] 영화관칩 깜빡거림 해결
- [ ] 로딩스피너 깜빡거림 해결

트러블슈팅에 크게 적을만한 게 없어서 추가적으로 개선 중인데,
로딩스피너 깜빡거림도 해결해야 하지만 일단 재배포해야 하니까 먼저 올려요!

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
useQuery에 `placeholderData: keepPreviousData` 옵션을 추가하였습니다.

단어 그대로,
- `placeholderData`는 쿼리가 로딩 중일 때 사용할 임시 데이터를 지정할 수 있는 속성이고, 
- `keepPreviousData`는 데이터 패칭 중 이전 쿼리의 데이터를 유지할 수 있도록 하는 속성값입니다.

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
- 개선 전

영화 선택 때마다 영화관 API 호출해서 해당 영화를 상영하는 영화관 정보를 불러오는데, 이때 영화관칩이 깜빡거림. 특히 이미 선택되어있던 영화관칩도 깜빡거리는 게 사용자 경험이 좋지 않을 것 같다고 생각함. 

![개선 전](https://github.com/user-attachments/assets/f6a55bc3-2773-437a-8ada-a6f07fe59cde)

- 개선 후

영화 선택 시 이미 선택되어있던 영화관칩은 깜빡거리지 않음!

![개선 후](https://github.com/user-attachments/assets/a5adeeb5-106d-45b5-9e9a-83508d3a08e0)

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
