### PR TITLE
[Refactor/#85] 예매 페이지 깜빡거림 개선

### DIFF
--- a/src/pages/movie-reservation/components/Carousel.tsx
+++ b/src/pages/movie-reservation/components/Carousel.tsx
@@ -1,25 +1,19 @@
 import { cn } from '@utils/cn';
 import { MOVIES } from '@constants/movies';
-
-import { type Date } from '@pages/movie-reservation/types/date';
-import { type ShowtimeReadRequest } from 'apis/data-contracts';
+import type { PrefetchConfig } from '@pages/movie-reservation/types/index';
 
 interface CarouselProps {
   selectedMovieIds: number[];
   initialSelectedMovie: number;
-  handleClick: (_id: number) => void;
-  prefetchShowtimes: (_: ShowtimeReadRequest) => void;   // ⭐ 추가
-  selectedDate: Date;                                  // ⭐ 추가
-  selectedTimeSlot: ShowtimeReadRequest['timeSlot'];     // ⭐ 추가
+  handleClickMovie: (_id: number) => void;
+  prefetchConfig: PrefetchConfig;
 }
 
 export default function Carousel({
   selectedMovieIds,
   initialSelectedMovie,
-  handleClick,
-  prefetchShowtimes,
-  selectedDate,
-  selectedTimeSlot,
+  handleClickMovie,
+  prefetchConfig
 }: CarouselProps) {
   const moviesWithSelectedFirst = Object.values(MOVIES).sort((a, b) => {
     if (a.id === initialSelectedMovie) return -1;
@@ -38,13 +32,14 @@ export default function Carousel({
                 ? 'border-gray-0 rounded-[0.4rem] border'
                 : 'rounded-[0.6rem] border border-transparent opacity-30'
             )}
-            onClick={() => handleClick(movie.id)}
+            onClick={() => handleClickMovie(movie.id)}
             onMouseEnter={() =>
-              prefetchShowtimes({
-                movieIds: [movie.id, ...selectedMovieIds.filter(id => id !== movie.id)].sort(),
-                // movieIds: selectedMovieIds,
-                date: selectedDate.date,
-                timeSlot: selectedTimeSlot,
+              prefetchConfig.prefetchShowtimes(prefetchConfig.queryClient, {
+                movieIds: selectedMovieIds.includes(movie.id)
+                            ? selectedMovieIds.filter(id => id !== movie.id)
+                            : [movie.id, ...selectedMovieIds.filter(id => id !== movie.id)],
+                date: prefetchConfig.date,
+                timeSlot: prefetchConfig.timeSlot,
               })
             }
           >

--- a/src/pages/movie-reservation/components/Carousel.tsx
+++ b/src/pages/movie-reservation/components/Carousel.tsx
@@ -1,16 +1,25 @@
 import { cn } from '@utils/cn';
 import { MOVIES } from '@constants/movies';
 
+import { type Date } from '@pages/movie-reservation/types/date';
+import { type ShowtimeReadRequest } from 'apis/data-contracts';
+
 interface CarouselProps {
   selectedMovieIds: number[];
   initialSelectedMovie: number;
   handleClick: (_id: number) => void;
+  prefetchShowtimes: (_: ShowtimeReadRequest) => void;   // ⭐ 추가
+  selectedDate: Date;                                  // ⭐ 추가
+  selectedTimeSlot: ShowtimeReadRequest['timeSlot'];     // ⭐ 추가
 }
 
 export default function Carousel({
   selectedMovieIds,
   initialSelectedMovie,
   handleClick,
+  prefetchShowtimes,
+  selectedDate,
+  selectedTimeSlot,
 }: CarouselProps) {
   const moviesWithSelectedFirst = Object.values(MOVIES).sort((a, b) => {
     if (a.id === initialSelectedMovie) return -1;
@@ -30,6 +39,14 @@ export default function Carousel({
                 : 'rounded-[0.6rem] border border-transparent opacity-30'
             )}
             onClick={() => handleClick(movie.id)}
+            onMouseEnter={() =>
+              prefetchShowtimes({
+                movieIds: [movie.id, ...selectedMovieIds.filter(id => id !== movie.id)].sort(),
+                // movieIds: selectedMovieIds,
+                date: selectedDate.date,
+                timeSlot: selectedTimeSlot,
+              })
+            }
           >
             <img src={movie.image} className='w-full h-full rounded-[0.4rem] object-cover' />
           </button>

--- a/src/pages/movie-reservation/hooks/index.ts
+++ b/src/pages/movie-reservation/hooks/index.ts
@@ -3,5 +3,5 @@ export { useSelection } from '@pages/movie-reservation/hooks/use-selection';
 export { useModalDetail } from '@pages/movie-reservation/hooks/use-modal-detail';
 export { useDate } from '@pages/movie-reservation/hooks/use-date';
 export { useCinemas } from '@pages/movie-reservation/hooks/use-cinemas';
-export { useShowtimes } from '@pages/movie-reservation/hooks/use-showtimes';
+export { useShowtimes, prefetchShowtimes } from '@pages/movie-reservation/hooks/use-showtimes';
 export { useOneShowtime } from '@pages/movie-reservation/hooks/use-one-showtime';

--- a/src/pages/movie-reservation/hooks/use-showtimes.ts
+++ b/src/pages/movie-reservation/hooks/use-showtimes.ts
@@ -22,6 +22,13 @@ async function apiGetShowtimesFixed(params: ShowtimeReadRequest) {
   return response.data.data?.cinemas;
 }
 
+const showtimesKey = (params: ShowtimeReadRequest) => [
+  'showtimes',
+  JSON.stringify([...(params.movieIds ?? [])].sort((a, b) => a - b)),
+  params.date,
+  params.timeSlot ?? null,
+];
+
 /**
  * 상영정보 조회 API
  * @param movieIds 선택된 영화들
@@ -35,9 +42,11 @@ export function useShowtimes({
   timeSlot
 }: ShowtimeReadRequest) {
   return useQuery({
-    queryKey: ['showtimes', movieIds, date, timeSlot],
+    // queryKey: ['showtimes', movieIds, date, timeSlot],
+    queryKey: showtimesKey({ movieIds, date, timeSlot }),
     queryFn: () =>
       apiGetShowtimesFixed({ movieIds, date, timeSlot }),
     enabled: movieIds && movieIds.length > 0,
+    staleTime: 1000 * 60,
   });
 }

--- a/src/pages/movie-reservation/hooks/use-showtimes.ts
+++ b/src/pages/movie-reservation/hooks/use-showtimes.ts
@@ -1,8 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import { useQuery, type QueryClient } from '@tanstack/react-query';
 import { type ShowtimeReadRequest } from 'apis/data-contracts';
+import { showtimesKey } from '@pages/movie-reservation/utils/showtimes-key';
 
-async function apiGetShowtimesFixed(params: ShowtimeReadRequest) {
+async function getShowtimes(params: ShowtimeReadRequest) {
   const { movieIds, date, timeSlot } = params;
 
   const response = await axios.get(
@@ -22,13 +23,6 @@ async function apiGetShowtimesFixed(params: ShowtimeReadRequest) {
   return response.data.data?.cinemas;
 }
 
-const showtimesKey = (params: ShowtimeReadRequest) => [
-  'showtimes',
-  JSON.stringify([...(params.movieIds ?? [])].sort((a, b) => a - b)),
-  params.date,
-  params.timeSlot ?? null,
-];
-
 /**
  * 상영정보 조회 API
  * @param movieIds 선택된 영화들
@@ -36,17 +30,22 @@ const showtimesKey = (params: ShowtimeReadRequest) => [
  * @param timeSlot 선택된 시간대
  * @returns 조건에 해당하는 상영정보 배열
  */
-export function useShowtimes({
-  movieIds,
-  date,
-  timeSlot
-}: ShowtimeReadRequest) {
+export function useShowtimes(params: ShowtimeReadRequest) {
   return useQuery({
-    // queryKey: ['showtimes', movieIds, date, timeSlot],
-    queryKey: showtimesKey({ movieIds, date, timeSlot }),
-    queryFn: () =>
-      apiGetShowtimesFixed({ movieIds, date, timeSlot }),
-    enabled: movieIds && movieIds.length > 0,
+    queryKey: showtimesKey(params),
+    queryFn: () => getShowtimes(params),
+    enabled: params.movieIds && params.movieIds.length > 0,
     staleTime: 1000 * 60,
   });
 }
+
+export async function prefetchShowtimes(queryClient: QueryClient, params: ShowtimeReadRequest) {
+  if (!params.movieIds?.length) return;
+
+  await queryClient.prefetchQuery({
+    queryKey: showtimesKey(params),
+    queryFn: () => getShowtimes(params),
+    staleTime: 1000 * 60,
+    gcTime: 1000 * 60 * 5,
+  });
+};

--- a/src/pages/movie-reservation/section/DateChips.tsx
+++ b/src/pages/movie-reservation/section/DateChips.tsx
@@ -1,26 +1,20 @@
 import dayjs from 'dayjs';
 import { cn } from '@utils/cn';
 import { Chip } from '@pages/movie-reservation/components/index';
-import { type Date } from '@pages/movie-reservation/types/date';
-
-import { type ShowtimeReadRequest } from 'apis/data-contracts';
+import type { Date, PrefetchConfig } from '@pages/movie-reservation/types/index';
 
 interface DateChipsProps {
   dates: Date[];
   selectedDate: Date;
   handleClickDate: (_: Date) => void;
-  movieIds: number[];
-  timeSlot: ShowtimeReadRequest['timeSlot'];
-  prefetchShowtimes: (_: ShowtimeReadRequest) => void;
+  prefetchConfig: PrefetchConfig;
 }
 
 export default function DateChips({
   dates,
   selectedDate,
   handleClickDate,
-  movieIds,
-  timeSlot,
-  prefetchShowtimes,
+  prefetchConfig,
 }: DateChipsProps) {
   return (
     <div className='scrollbar-hide flex w-full gap-[0.7rem] overflow-x-scroll px-[0.5rem]'>
@@ -38,11 +32,10 @@ export default function DateChips({
             isSelected={selectedDate.date === dateInfo.date}
             onClick={() => handleClickDate(dateInfo)}
             onMouseEnter={() => {
-              console.log('hi');
-              prefetchShowtimes({
-                movieIds,
+              prefetchConfig.prefetchShowtimes(prefetchConfig.queryClient, {
+                movieIds: prefetchConfig.movieIds,
                 date: dateInfo.date,
-                timeSlot,
+                timeSlot: prefetchConfig.timeSlot,
               })
             }}
           >

--- a/src/pages/movie-reservation/section/DateChips.tsx
+++ b/src/pages/movie-reservation/section/DateChips.tsx
@@ -3,16 +3,24 @@ import { cn } from '@utils/cn';
 import { Chip } from '@pages/movie-reservation/components/index';
 import { type Date } from '@pages/movie-reservation/types/date';
 
+import { type ShowtimeReadRequest } from 'apis/data-contracts';
+
 interface DateChipsProps {
   dates: Date[];
   selectedDate: Date;
   handleClickDate: (_: Date) => void;
+  movieIds: number[];
+  timeSlot: ShowtimeReadRequest['timeSlot'];
+  prefetchShowtimes: (_: ShowtimeReadRequest) => void;
 }
 
 export default function DateChips({
   dates,
   selectedDate,
-  handleClickDate
+  handleClickDate,
+  movieIds,
+  timeSlot,
+  prefetchShowtimes,
 }: DateChipsProps) {
   return (
     <div className='scrollbar-hide flex w-full gap-[0.7rem] overflow-x-scroll px-[0.5rem]'>
@@ -29,6 +37,14 @@ export default function DateChips({
             variant='date'
             isSelected={selectedDate.date === dateInfo.date}
             onClick={() => handleClickDate(dateInfo)}
+            onMouseEnter={() => {
+              console.log('hi');
+              prefetchShowtimes({
+                movieIds,
+                date: dateInfo.date,
+                timeSlot,
+              })
+            }}
           >
             <span className={cn('font-title3', dayColorClass)}>
               {dateString}

--- a/src/pages/movie-reservation/section/TimeChips.tsx
+++ b/src/pages/movie-reservation/section/TimeChips.tsx
@@ -1,14 +1,23 @@
-import { TIMES } from '@pages/movie-reservation/constants/index';
+import { TIMES, type TimeType } from '@pages/movie-reservation/constants/index';
 import { Chip } from '@pages/movie-reservation/components/index';
+
+import { type Date } from '@pages/movie-reservation/types/date';
+import { type ShowtimeReadRequest } from 'apis/data-contracts';
 
 interface TimeChipsProps {
   selectedTimeId: number | null;
   handleClickTime: (_: number) => void;
+  movieIds: number[];
+  selectedDate: Date;                                  // ⭐ 추가
+  prefetchShowtimes: (_: ShowtimeReadRequest) => void;
 }
 
 export default function TimeChips({
   selectedTimeId,
-  handleClickTime
+  handleClickTime,
+  movieIds,
+  selectedDate,
+  prefetchShowtimes
 }: TimeChipsProps) {
   return (
     <div className='scrollbar-hide flex w-full items-start gap-[0.8rem] overflow-x-scroll py-[1rem] opacity-70'>
@@ -19,6 +28,14 @@ export default function TimeChips({
             variant='time'
             isSelected={selectedTimeId === idx}
             onClick={() => handleClickTime(idx)}
+            onMouseEnter={() => {
+              console.log('hi');
+              prefetchShowtimes({
+                movieIds,
+                date: selectedDate.date,
+                timeSlot: TIMES[idx].type as TimeType
+              })
+            }}
           >
             {TIMES[idx].label}
           </Chip>

--- a/src/pages/movie-reservation/section/TimeChips.tsx
+++ b/src/pages/movie-reservation/section/TimeChips.tsx
@@ -1,23 +1,17 @@
 import { TIMES, type TimeType } from '@pages/movie-reservation/constants/index';
 import { Chip } from '@pages/movie-reservation/components/index';
-
-import { type Date } from '@pages/movie-reservation/types/date';
-import { type ShowtimeReadRequest } from 'apis/data-contracts';
+import type { PrefetchConfig } from '@pages/movie-reservation/types/index';
 
 interface TimeChipsProps {
   selectedTimeId: number | null;
   handleClickTime: (_: number) => void;
-  movieIds: number[];
-  selectedDate: Date;                                  // ⭐ 추가
-  prefetchShowtimes: (_: ShowtimeReadRequest) => void;
+  prefetchConfig: PrefetchConfig;
 }
 
 export default function TimeChips({
   selectedTimeId,
   handleClickTime,
-  movieIds,
-  selectedDate,
-  prefetchShowtimes
+  prefetchConfig,
 }: TimeChipsProps) {
   return (
     <div className='scrollbar-hide flex w-full items-start gap-[0.8rem] overflow-x-scroll py-[1rem] opacity-70'>
@@ -29,10 +23,9 @@ export default function TimeChips({
             isSelected={selectedTimeId === idx}
             onClick={() => handleClickTime(idx)}
             onMouseEnter={() => {
-              console.log('hi');
-              prefetchShowtimes({
-                movieIds,
-                date: selectedDate.date,
+              prefetchConfig.prefetchShowtimes(prefetchConfig.queryClient, {
+                movieIds: prefetchConfig.movieIds,
+                date: prefetchConfig.date,
                 timeSlot: TIMES[idx].type as TimeType
               })
             }}

--- a/src/pages/movie-reservation/types/index.ts
+++ b/src/pages/movie-reservation/types/index.ts
@@ -1,3 +1,4 @@
 export { type Date } from './date';
 export { type ShowtimeDetail } from './showtime-detail';
 export { type AgeRating } from './age-rating';
+export { type PrefetchConfig } from './prefetch-config';

--- a/src/pages/movie-reservation/types/prefetch-config.ts
+++ b/src/pages/movie-reservation/types/prefetch-config.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+import { type ShowtimeReadRequest } from 'apis/data-contracts';
+
+export interface PrefetchConfig {
+  movieIds?: number[];
+  date?: string;
+  timeSlot?: ShowtimeReadRequest['timeSlot'];
+  queryClient: QueryClient;
+  prefetchShowtimes: (_: QueryClient, __: ShowtimeReadRequest) => void;
+}

--- a/src/pages/movie-reservation/utils/showtimes-key.ts
+++ b/src/pages/movie-reservation/utils/showtimes-key.ts
@@ -1,0 +1,8 @@
+import { type ShowtimeReadRequest } from 'apis/data-contracts';
+
+export const showtimesKey = (params: ShowtimeReadRequest) => [
+  'showtimes',
+  JSON.stringify([...(params.movieIds ?? [])].sort((a, b) => a - b)),
+  params.date,
+  params.timeSlot ?? null,
+];


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #85 

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

<!-- 작업한 내용을 작성해주세요 -->
로딩 스피너 깜빡거림을 개선했어요.

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
- 영화관칩 깜빡거림을 해결했던 것과 같이 `placeholderData: keepPreviousData`로도 해결 가능하고,
- 실제로 적용한 방법은 `onMouseEnter` 이벤트 핸들러로 `prefetchShowtimes`를 연결해줬어요.
칩 위에 마우스가 hover되면 사용자가 해당 칩을 선택할 것으로 예상하고 데이터를 미리 캐시해둬요.

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

- 변경 전

자꾸 로딩 스피너가 0.1초 떴다가 사라져요.
![트슈2 - 개선 전](https://github.com/user-attachments/assets/2c53308e-d5fe-48e2-ad7c-5ea6a33554ff)


- 변경 후

로딩 스피너가 뜨지 않고 바로 상영 정보를 렌더링하고,
tanstack devtools를 보면 칩 위에 마우스가 hover되기만 해도 데이터가 캐시되는 것을 확인할 수 있어요!
![트슈2 - 개선 후](https://github.com/user-attachments/assets/7089c580-eede-4509-bd21-f90824da7dd8)
![트슈2 - 개선 후 devtools](https://github.com/user-attachments/assets/349d9adf-9c3e-426b-911e-6f3b8301850e)


## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
